### PR TITLE
Improve section reveal behavior and animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
       <span>Scroll for more</span>
     </div>
 
-    <section class="projects-section fade-in">
+    <section class="projects-section fade-in manual-control">
       <h2>Main Projects</h2>
       <div class="carousel">
         <button id="prev-btn" class="carousel-btn prev">&#8249;</button>
@@ -70,7 +70,7 @@
       </div>
     </section>
 
-    <section class="projects-section fade-in">
+    <section class="projects-section fade-in manual-control">
       <h2>Side Projects</h2>
       <div id="side-projects" class="projects"></div>
       <button id="side-projects-next" style="margin: 2rem auto 0 auto; display: block; padding: 0.8em 2em; font-size: 1.1em; border-radius: 8px; border: none; background: #222; color: #fff; cursor: pointer;">Load Next</button>

--- a/script.js
+++ b/script.js
@@ -126,6 +126,8 @@ window.addEventListener('resize', () => {
   renderSideProjects();
 });
 
+const MOBILE_MAX_WIDTH = 900;
+
 document.addEventListener('DOMContentLoaded', () => {
   displayRepos();
   initScrollAnimations();
@@ -140,14 +142,18 @@ document.addEventListener('DOMContentLoaded', () => {
   const aboutSection = document.querySelector('.about-container');
   const readMoreBtn = document.getElementById('about-read-more');
   if (aboutSection && readMoreBtn) {
-    readMoreBtn.addEventListener('click', function() {
-      aboutSection.classList.toggle('expanded');
-      if (aboutSection.classList.contains('expanded')) {
-        readMoreBtn.textContent = 'Show Less';
+    readMoreBtn.addEventListener('click', function(e) {
+      if (window.innerWidth <= MOBILE_MAX_WIDTH) {
+        e.preventDefault();
+        showAboutPopup();
       } else {
-        readMoreBtn.textContent = 'Read More';
-        // Scroll back to top of about section if collapsed
-        aboutSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        aboutSection.classList.toggle('expanded');
+        if (aboutSection.classList.contains('expanded')) {
+          readMoreBtn.textContent = 'Show Less';
+        } else {
+          readMoreBtn.textContent = 'Read More';
+          aboutSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
       }
     });
   }
@@ -192,36 +198,27 @@ document.addEventListener('DOMContentLoaded', () => {
     if (extra) extra.querySelectorAll('p').forEach(p => paragraphs.push(p.textContent));
     setAboutPopupParagraphs(paragraphs);
   }
-  // Show popup on Read More for mobile/tablet
-  function setupReadMorePopup() {
-    const readMoreBtn = document.getElementById('about-read-more');
-    if (!readMoreBtn) return;
-    readMoreBtn.addEventListener('click', function(e) {
-      if (window.innerWidth <= 900) {
-        e.preventDefault();
-        setupAboutPopup();
-        showAboutPopup();
-      }
-    });
-  }
+
+  setupAboutPopup();
 
   // Scroll-triggered transitions
   let triggered = false;
-  window.addEventListener('scroll', function() {
+  function handleScroll() {
     const about = document.querySelector('.about-container');
     const profile = document.querySelector('.profile-pic');
     const hero = document.querySelector('.hero-text');
     const mainSections = document.querySelectorAll('.projects-section');
     const scrollForMore = document.querySelector('.scroll-for-more');
-    const triggerPoint = window.innerHeight * 0.35;
-    if (window.scrollY > triggerPoint && !triggered) {
+    const aboutBottom = about.getBoundingClientRect().bottom;
+    const threshold = window.innerHeight * 0.2;
+    if (aboutBottom <= threshold && !triggered) {
       about.classList.add('fade-out');
       profile.classList.add('sticky');
       hero.classList.add('shrink-move');
       mainSections.forEach(s => s.classList.add('visible'));
       if (scrollForMore) scrollForMore.classList.add('hide');
       triggered = true;
-    } else if (window.scrollY <= triggerPoint && triggered) {
+    } else if (aboutBottom > threshold && triggered) {
       about.classList.remove('fade-out');
       profile.classList.remove('sticky');
       hero.classList.remove('shrink-move');
@@ -229,7 +226,9 @@ document.addEventListener('DOMContentLoaded', () => {
       if (scrollForMore) scrollForMore.classList.remove('hide');
       triggered = false;
     }
-  });
+  }
+  window.addEventListener('scroll', handleScroll);
+  handleScroll();
 
   // Hide main/side projects initially
   document.querySelectorAll('.projects-section').forEach(s => s.classList.remove('visible'));
@@ -238,7 +237,6 @@ document.addEventListener('DOMContentLoaded', () => {
   if (scrollForMore) scrollForMore.classList.remove('hide');
 
   document.getElementById('side-projects-next').addEventListener('click', handleSideProjectsNext);
-  setupReadMorePopup();
 });
 
 async function displayRepos() {
@@ -323,5 +321,9 @@ function initScrollAnimations() {
     });
   }, { threshold: 0.1 });
 
-  document.querySelectorAll('.fade-in').forEach(el => observer.observe(el));
+  document.querySelectorAll('.fade-in').forEach(el => {
+    if (!el.classList.contains('manual-control')) {
+      observer.observe(el);
+    }
+  });
 }

--- a/styles.css
+++ b/styles.css
@@ -268,11 +268,13 @@ header {
   margin: 4vw 0 2vw 0;
   opacity: 0;
   pointer-events: none;
-  transition: opacity 0.8s cubic-bezier(0.4,0,0.2,1);
+  transform: translateY(30px);
+  transition: opacity 0.8s cubic-bezier(0.4,0,0.2,1), transform 0.8s cubic-bezier(0.4,0,0.2,1);
 }
 .projects-section.visible {
   opacity: 1;
   pointer-events: auto;
+  transform: none;
 }
 .projects-section h2 {
   font-size: 2rem;
@@ -645,7 +647,8 @@ body > *:not(#background-fader) {
   font-size: 1.2em;
   color: #eee;
   opacity: 1;
-  transition: opacity 0.7s;
+  transform: translateY(0);
+  transition: opacity 0.7s, transform 0.7s;
   z-index: 10;
   pointer-events: auto;
 }
@@ -659,6 +662,7 @@ body > *:not(#background-fader) {
 }
 .scroll-for-more.hide {
   opacity: 0;
+  transform: translateY(-20px);
   pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary
- keep project sections hidden until the About area scrolls out of view
- refine "Read More" behaviour: mobile shows a popup carousel and desktop expands text
- exclude manually–controlled sections from generic fade-in observer
- add smooth transforms for project sections and scroll hint fade

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_685c87ea68988328995eb6b3626a83f2