### PR TITLE
Fix mobile navigation and polish portfolio layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -1076,6 +1076,7 @@ function initMobileNav() {
 
   function closeMobileNav(returnFocus) {
     mobileNav.classList.remove('open');
+    document.body.classList.remove('nav-open');
     hamburger.classList.remove('active');
     hamburger.setAttribute('aria-expanded', 'false');
     mobileNav.setAttribute('aria-hidden', 'true');
@@ -1084,6 +1085,7 @@ function initMobileNav() {
 
   hamburger.addEventListener('click', function () {
     const isOpen = mobileNav.classList.toggle('open');
+    document.body.classList.toggle('nav-open', isOpen);
     hamburger.classList.toggle('active', isOpen);
     hamburger.setAttribute('aria-expanded', String(isOpen));
     mobileNav.setAttribute('aria-hidden', String(!isOpen));

--- a/styles.css
+++ b/styles.css
@@ -35,12 +35,16 @@
 .professional-cta h2 { margin-top:0; }
 .professional-cta .btn { margin:.5rem .5rem 0 0; }
 .creative-feature { display:grid; grid-template-columns:minmax(0,1.1fr) minmax(0,.9fr); gap:3rem; align-items:center; margin-top:3rem; }
+.creative-hero-section { background:radial-gradient(circle at 82% 18%,rgba(100,255,218,.12),transparent 26rem),linear-gradient(180deg,rgba(17,34,64,.55),transparent 70%); }
+.creative-hero-section .research-heading,.professional-hero .research-heading { align-items:end; }
+.creative-hero-section .research-intro,.professional-hero .research-intro { max-width:34rem; }
 .creative-portrait { margin:0; border-radius:1.5rem; overflow:hidden; max-height:34rem; }
 .creative-portrait img { width:100%; height:100%; object-fit:cover; object-position:center; display:block; }
 .creative-feature-copy h2 { font-size:clamp(2rem,4vw,3.5rem); margin:.7rem 0 1rem; }
 .creative-feature-copy p { color:var(--text-muted); line-height:1.7; max-width:34rem; }
 .creative-grid { display:grid; grid-template-columns:repeat(2,1fr); gap:1rem; margin-top:2rem; }
 .creative-card { display:block; min-height:15rem; padding:1.6rem; border:1px solid rgba(148,163,184,.22); border-radius:1.25rem; background:rgba(15,23,42,.72); transition:transform .25s ease,border-color .25s ease; }
+.creative-card:focus-visible,.work-path:focus-visible,.capability-card:focus-visible { outline:2px solid var(--accent2); outline-offset:4px; }
 .creative-card:hover { transform:translateY(-4px); border-color:rgba(56,189,248,.65); }
 .creative-card h3 { margin:.8rem 0 .5rem; font-size:1.3rem; }
 .creative-card b { color:var(--accent,#38bdf8); font-size:.85rem; }
@@ -154,6 +158,7 @@ body > *:not(#matrix-bg):not(#background-fader) {
   border-bottom: 1px solid rgba(100, 255, 218, 0.07);
   z-index: 1000;
   transition: box-shadow var(--transition);
+  isolation: isolate;
 }
 
 #navbar.scrolled {
@@ -168,6 +173,7 @@ body > *:not(#matrix-bg):not(#background-fader) {
   display: flex;
   align-items: center;
   gap: 2rem;
+  min-width: 0;
 }
 
 .nav-logo {
@@ -272,12 +278,16 @@ body > *:not(#matrix-bg):not(#background-fader) {
   top: var(--nav-h);
   left: 0;
   right: 0;
-  background: rgba(10, 25, 47, 0.97);
+  background: #0a192f;
   backdrop-filter: blur(14px);
   -webkit-backdrop-filter: blur(14px);
   border-bottom: 1px solid rgba(100, 255, 218, 0.08);
   z-index: 999;
   padding: 0.5rem 0 1rem;
+  max-height: calc(100dvh - var(--nav-h));
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  box-shadow: 0 18px 32px rgba(0, 0, 0, 0.28);
 }
 
 .mobile-nav.open {
@@ -291,13 +301,15 @@ body > *:not(#matrix-bg):not(#background-fader) {
 
 .mobile-nav-link {
   display: block;
-  padding: 1rem 2rem;
+  padding: 1.05rem 2rem;
   color: var(--text);
   font-size: 1.05rem;
   font-weight: 500;
   border-bottom: 1px solid rgba(255, 255, 255, 0.05);
   transition: color var(--transition), background var(--transition);
 }
+
+body.nav-open { overflow: hidden; }
 
 .mobile-nav-link:hover,
 .mobile-nav-link[aria-current="location"],
@@ -2305,7 +2317,17 @@ body > .back-to-top {
 
   .hamburger {
     display: flex;
+    width: 42px;
+    height: 42px;
+    align-items: center;
+    justify-content: center;
+    border-radius: 999px;
+    background: rgba(100, 255, 218, 0.06);
+    border: 1px solid rgba(100, 255, 218, 0.18);
   }
+
+  .nav-container { padding: 0 1.25rem; }
+  .mobile-nav-link { padding-left: 1.25rem; padding-right: 1.25rem; }
 
   .section {
     padding: 3rem 0;


### PR DESCRIPTION
## What changed
- Make the mobile menu opaque, bounded to the viewport and scroll-safe.
- Lock page scrolling while the menu is open and restore it on close.
- Improve mobile hamburger affordance and navigation spacing.
- Add subtle visual hierarchy and focus states to the creative/professional routes.

## Validation
- `git diff --check`
- Verified navigation hooks on all portfolio pages.
