### PR TITLE
Compact mobile layout and footer

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3442,6 +3442,7 @@ body > .back-to-top {
 .scroll-progress { position:fixed; top:0; left:0; z-index:1200; width:100%; height:3px; transform:scaleX(0); transform-origin:left center; background:linear-gradient(90deg,var(--accent),var(--accent2),#c084fc); pointer-events:none; }
 .words-ready { overflow:visible; }
 .js .word-reveal { display:inline-block; opacity:0; transform:translateY(.7em); transition:opacity .55s ease,transform .55s cubic-bezier(.22,.61,.36,1); transition-delay:calc(var(--word-index) * 45ms); }
+.word-reveal { max-width:100%; white-space:normal; }
 .js .words-visible .word-reveal { opacity:1; transform:none; }
 .home-page main,.standalone-main { scroll-snap-type:y proximity; }
 .home-page main > section,.standalone-main > section { scroll-snap-align:start; }
@@ -3469,10 +3470,11 @@ body > .back-to-top {
   .home-page .hero-text h1 { font-size:clamp(2rem,10vw,3rem); }
   .home-page .hero-subtitle { font-size:1rem; }
   .home-page .hero-location { font-size:.84rem; }
-  .home-page .work-paths { display:flex; overflow-x:auto; scroll-snap-type:x mandatory; gap:.8rem; padding:.25rem .15rem 1rem; scrollbar-width:none; }
+  .home-page .work-paths { display:flex; width:100%; max-width:100%; overflow-x:auto; scroll-snap-type:x mandatory; gap:0; padding:.25rem 0 1rem; scrollbar-width:none; scroll-padding-inline:0; }
   .home-page .work-paths::-webkit-scrollbar { display:none; }
-  .home-page .work-path { flex:0 0 86vw; min-height:230px; scroll-snap-align:start; }
-  .home-page .work-directory-heading h2 { font-size:clamp(2rem,9vw,3rem); }
+  .home-page .work-path { flex:0 0 100%; width:100%; min-width:0; min-height:230px; scroll-snap-align:start; }
+  .home-page .work-directory-heading,.home-page .work-directory-heading h2,.home-page .work-directory-heading > p { width:100%; max-width:100%; min-width:0; overflow-wrap:anywhere; }
+  .home-page .work-directory-heading h2 { font-size:clamp(2rem,9vw,3rem); text-wrap:balance; }
   .home-page .contact-layout { gap:1.2rem; }
   .home-page .contact-form { padding:1.1rem; }
   .home-page .contact-form-message textarea { min-height:90px; }
@@ -3488,6 +3490,19 @@ body > .back-to-top {
   .creative-video-tile { grid-column:1 / -1; }
   .research-carousel .research-feature { display:grid; }
   .professional-carousel .professional-role { min-height:15rem; }
+  .site-footer { padding:2.5rem 0 1rem; }
+  .site-footer .container { padding-left:1.25rem; padding-right:1.25rem; }
+  .site-footer .footer-grid { grid-template-columns:repeat(2,minmax(0,1fr)); gap:1.25rem .9rem; }
+  .site-footer .footer-intro,.site-footer .footer-socials { grid-column:1 / -1; }
+  .site-footer .footer-intro h2 { font-size:clamp(1.65rem,7vw,2.2rem); line-height:1.05; margin-bottom:.7rem; }
+  .site-footer .footer-intro p { max-width:32rem; font-size:.85rem; line-height:1.45; }
+  .site-footer .footer-column { gap:.4rem; }
+  .site-footer .footer-label { margin-bottom:.3rem; }
+  .site-footer .footer-column a { font-size:.82rem; line-height:1.35; }
+  .site-footer .footer-socials { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:.55rem .8rem; }
+  .site-footer .footer-socials .footer-label { grid-column:1 / -1; }
+  .site-footer .footer-bottom { flex-direction:row; flex-wrap:wrap; align-items:center; justify-content:space-between; gap:.35rem .75rem; padding-top:1rem; margin-top:1rem; }
+  .site-footer .footer-bottom p { font-size:.72rem; }
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## What changed
- Prevent the mobile work-card carousel and heading from overflowing the viewport.
- Show one complete snap card at a time while retaining swipe navigation.
- Compact the mobile footer into a two-column layout with a two-column socials grid.
- Preserve all footer links and contact information.

## Validation
- `node --check script.js`
- `git diff --check`
