### PR TITLE
Add work carousel cues and interactive about overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,7 +103,10 @@
     <section id="hero" class="hero-section">
       <div class="hero-content">
         <div class="hero-image-wrap fade-in">
-          <img src="assets/graduation/pgdip-distinction-portrait.webp" alt="Nathan Brown-Bennett at his Kingston University London graduation" class="hero-profile-pic" width="1200" height="1600" fetchpriority="high" decoding="async" />
+          <button class="hero-image-trigger" id="about-trigger" type="button" aria-label="Read about Nathan Brown-Bennett">
+            <img src="assets/graduation/pgdip-distinction-portrait.webp" alt="Nathan Brown-Bennett at his Kingston University London graduation" class="hero-profile-pic" width="1200" height="1600" fetchpriority="high" decoding="async" />
+          </button>
+          <span class="hero-image-note">click me to read me <span aria-hidden="true">↗</span></span>
         </div>
         <div class="hero-text fade-in">
           <p class="hero-greeting">Hi, I'm</p>
@@ -119,6 +122,17 @@
         </div>
       </div>
     </section>
+
+    <div class="about-overlay" id="about-overlay" role="dialog" aria-modal="true" aria-labelledby="about-overlay-title" aria-hidden="true">
+      <div class="about-overlay-card">
+        <button class="about-overlay-close" id="about-overlay-close" type="button" aria-label="Close About Me">×</button>
+        <p class="projects-eyebrow">About me</p>
+        <h2 id="about-overlay-title">Researcher, builder and creative technologist.</h2>
+        <p>I'm Nathan Brown-Bennett, a creative technologist with a Postgraduate Diploma in Network and Information Security, awarded with Distinction by Kingston University London. I research how people and organisations make safer technology decisions, then communicate those findings through useful systems, clear writing and creative work.</p>
+        <p>My practice sits between cybersecurity, software, education and performance. I am preparing to progress from the PGDip into the MSc while developing BstudioB as the company home for products and client-facing work.</p>
+        <a class="btn btn-primary" href="#about">View experience</a>
+      </div>
+    </div>
 
     <!-- ============================
          About Section
@@ -229,6 +243,7 @@
             <span class="work-path-action">View creative practice <span aria-hidden="true">↓</span></span>
           </a>
         </div>
+        <div class="work-carousel-assist" aria-label="Work carousel position"><span class="work-carousel-label">Swipe to explore</span><div class="work-carousel-dots" role="tablist" aria-label="Choose work category"><button type="button" class="work-carousel-dot active" data-work-slide="0" role="tab" aria-label="Research" aria-selected="true"></button><button type="button" class="work-carousel-dot" data-work-slide="1" role="tab" aria-label="Professional Work" aria-selected="false"></button><button type="button" class="work-carousel-dot" data-work-slide="2" role="tab" aria-label="Creative Practice" aria-selected="false"></button></div><span class="work-carousel-count">1 / 3</span></div>
       </div>
     </section>
 

--- a/script.js
+++ b/script.js
@@ -1178,6 +1178,46 @@ function initScrollAssist() {
   window.addEventListener('scroll', update, { passive: true });
 }
 
+function initWorkCarousel() {
+  const section = document.getElementById('work');
+  const track = section && section.querySelector('.work-paths');
+  const cards = track ? Array.from(track.querySelectorAll('.work-path')) : [];
+  const dots = section ? Array.from(section.querySelectorAll('.work-carousel-dot')) : [];
+  const count = section && section.querySelector('.work-carousel-count');
+  if (!track || cards.length < 2) return;
+  const update = function (index) {
+    section.classList.remove('work-slide-0', 'work-slide-1', 'work-slide-2');
+    section.classList.add('work-slide-' + index);
+    if (count) count.textContent = (index + 1) + ' / ' + cards.length;
+    dots.forEach(function (dot, dotIndex) { dot.classList.toggle('active', dotIndex === index); dot.setAttribute('aria-selected', String(dotIndex === index)); });
+  };
+  const nearest = function () {
+    const index = Math.max(0, Math.min(cards.length - 1, Math.round(track.scrollLeft / Math.max(1, track.clientWidth))));
+    update(index);
+  };
+  track.addEventListener('scroll', nearest, { passive: true });
+  dots.forEach(function (dot, index) { dot.addEventListener('click', function () { track.scrollTo({ left: index * track.clientWidth, behavior: 'smooth' }); update(index); }); });
+  update(0);
+}
+
+function initAboutOverlay() {
+  const overlay = document.getElementById('about-overlay');
+  const trigger = document.getElementById('about-trigger');
+  const close = document.getElementById('about-overlay-close');
+  if (!overlay || !trigger || !close) return;
+  const setOpen = function (open) {
+    overlay.classList.toggle('open', open);
+    overlay.setAttribute('aria-hidden', String(!open));
+    document.body.classList.toggle('overlay-open', open);
+    if (open) close.focus(); else trigger.focus();
+  };
+  trigger.addEventListener('click', function () { setOpen(true); });
+  close.addEventListener('click', function () { setOpen(false); });
+  overlay.querySelectorAll('a').forEach(function (link) { link.addEventListener('click', function () { setOpen(false); }); });
+  overlay.addEventListener('click', function (event) { if (event.target === overlay) setOpen(false); });
+  document.addEventListener('keydown', function (event) { if (event.key === 'Escape' && overlay.classList.contains('open')) setOpen(false); });
+}
+
 function initSectionNavigation() {
   if (!('IntersectionObserver' in window)) return;
 
@@ -1311,6 +1351,8 @@ document.addEventListener('DOMContentLoaded', function () {
   initNavbarScroll();
   initWordAnimations();
   initScrollAssist();
+  initWorkCarousel();
+  initAboutOverlay();
   initSectionNavigation();
   initContactFormStatus();
   initBackgroundFader();

--- a/styles.css
+++ b/styles.css
@@ -468,6 +468,14 @@ body.nav-open { overflow: hidden; }
   --path-accent: #c084fc;
   background: linear-gradient(145deg, rgba(70, 39, 83, 0.96), rgba(30, 23, 45, 0.98));
 }
+.work-path { background:rgba(20,28,52,.58); backdrop-filter:blur(18px) saturate(1.25); -webkit-backdrop-filter:blur(18px) saturate(1.25); }
+.work-carousel-assist { display:flex; align-items:center; justify-content:center; gap:1rem; margin-top:1rem; color:var(--text-muted); font-size:.68rem; text-transform:uppercase; letter-spacing:.1em; }
+.work-carousel-dots { display:flex; align-items:center; gap:.35rem; }
+.work-carousel-dot { width:.45rem; height:.45rem; padding:0; border:0; border-radius:50%; background:rgba(255,255,255,.35); cursor:pointer; }
+.work-carousel-dot.active { width:1.3rem; border-radius:999px; background:var(--accent2); }
+body.home-page #work.work-slide-0::before { background-image:linear-gradient(120deg,rgba(23,20,35,.52),rgba(23,20,35,.64)),url('assets/research/undergraduate-product-evidence.webp'); }
+body.home-page #work.work-slide-1::before { background-image:linear-gradient(120deg,rgba(23,20,35,.54),rgba(72,39,52,.58)),url('assets/Background_Images/standing.webp'); }
+body.home-page #work.work-slide-2::before { background-image:linear-gradient(120deg,rgba(23,20,35,.42),rgba(72,39,52,.56)),url('assets/Background_Images/performance.JPG'); }
 
 .work-path:hover {
   border-color: var(--path-accent);
@@ -664,6 +672,22 @@ body > .back-to-top {
   box-shadow: var(--shadow-lg);
   border: 2px solid rgba(100, 255, 218, 0.2);
 }
+.hero-image-wrap { position:relative; display:grid; justify-items:center; gap:.55rem; }
+.hero-image-trigger { position:relative; display:block; padding:0; border:0; background:none; cursor:pointer; border-radius:1.25rem; }
+.hero-image-trigger:focus-visible { outline:3px solid var(--accent2); outline-offset:5px; }
+.hero-image-trigger:hover .hero-profile-pic { transform:scale(1.025) rotate(-1deg); }
+.hero-image-note { color:var(--accent2); font-size:.72rem; font-weight:800; letter-spacing:.08em; text-transform:uppercase; }
+.hero-image-trigger::after { content:''; position:absolute; inset:-.35rem; border:1px solid rgba(244,201,93,.5); border-radius:1.45rem; pointer-events:none; animation:hero-nudge 3.8s ease-in-out infinite; }
+@keyframes hero-nudge { 0%,70%,100% { transform:rotate(0); } 74% { transform:rotate(-1.5deg); } 78% { transform:rotate(1.5deg); } 82% { transform:rotate(-.8deg); } 86% { transform:rotate(0); } }
+.overlay-open { overflow:hidden; }
+.about-overlay { position:fixed; inset:0; z-index:1150; display:grid; place-items:center; padding:1.25rem; background:rgba(12,10,20,.78); backdrop-filter:blur(18px); opacity:0; pointer-events:none; transition:opacity .25s ease; }
+.about-overlay.open { opacity:1; pointer-events:auto; }
+.about-overlay-card { position:relative; width:min(680px,100%); max-height:min(80svh,720px); overflow:auto; padding:clamp(1.5rem,5vw,3rem); border:1px solid rgba(244,201,93,.42); border-radius:1.5rem; background:linear-gradient(145deg,rgba(43,30,57,.92),rgba(21,19,34,.94)); box-shadow:0 30px 100px rgba(0,0,0,.45); transform:translateY(1rem) scale(.98); transition:transform .3s ease; }
+.about-overlay.open .about-overlay-card { transform:none; }
+.about-overlay-card h2 { max-width:15ch; margin:.5rem 0 1rem; color:var(--white); font-family:'Playfair Display',Georgia,serif; font-size:clamp(1.8rem,4vw,3rem); line-height:1.05; }
+.about-overlay-card p:not(.projects-eyebrow) { max-width:58ch; color:var(--text-muted); line-height:1.7; }
+.about-overlay-card .btn { margin-top:1.2rem; }
+.about-overlay-close { position:absolute; top:.8rem; right:1rem; width:2.4rem; height:2.4rem; border:1px solid rgba(244,201,93,.45); border-radius:50%; background:transparent; color:var(--white); cursor:pointer; font-size:1.5rem; line-height:1; }
 
 .hero-text {
   flex: 1;
@@ -3471,12 +3495,14 @@ body > .back-to-top {
   .home-page .experience-disclosure { margin-top:.8rem; }
   .home-page .hero-content { gap:1.1rem; }
   .home-page .hero-profile-pic { width:132px; height:132px; }
+  .hero-image-note { font-size:.62rem; }
   .home-page .hero-text h1 { font-size:clamp(2rem,10vw,3rem); }
   .home-page .hero-subtitle { font-size:1rem; }
   .home-page .hero-location { font-size:.84rem; }
   .home-page .work-paths { display:flex; width:100%; max-width:100%; overflow-x:auto; scroll-snap-type:x mandatory; gap:0; padding:.25rem 0 1rem; scrollbar-width:none; scroll-padding-inline:0; }
   .home-page .work-paths::-webkit-scrollbar { display:none; }
   .home-page .work-path { flex:0 0 100%; width:100%; min-width:0; min-height:230px; scroll-snap-align:start; }
+  .home-page .work-carousel-assist { justify-content:space-between; margin-top:.2rem; }
   .home-page .work-directory-heading,.home-page .work-directory-heading h2,.home-page .work-directory-heading > p { width:100%; max-width:100%; min-width:0; overflow-wrap:anywhere; }
   .home-page .work-directory-heading h2 { display:block; width:100%; max-width:100%; font-size:clamp(1.8rem,8vw,2.7rem); line-height:1.08; text-wrap:pretty; white-space:normal !important; }
   .home-page .work-directory-heading h2 .word-reveal { display:inline; white-space:normal; }


### PR DESCRIPTION
## What changed
- Add visible “Swipe to explore” carousel cues, dots and slide count to the homepage work cards.
- Change the work section background as the active card changes.
- Add translucent frosted-glass work cards.
- Make the hero graduation portrait clickable with a subtle shake and “click me to read me” note.
- Add an accessible About Me overlay with close, Escape and backdrop controls.

## Validation
- `node --check script.js`
- `git diff --check`
