### PR TITLE
Add experience details to About overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,7 +130,45 @@
         <h2 id="about-overlay-title">Researcher, builder and creative technologist.</h2>
         <p>I'm Nathan Brown-Bennett, a creative technologist with a Postgraduate Diploma in Network and Information Security, awarded with Distinction by Kingston University London. I research how people and organisations make safer technology decisions, then communicate those findings through useful systems, clear writing and creative work.</p>
         <p>My practice sits between cybersecurity, software, education and performance. I am preparing to progress from the PGDip into the MSc while developing BstudioB as the company home for products and client-facing work.</p>
-        <a class="btn btn-primary" href="#about">View experience</a>
+        <div class="about-overlay-experience">
+          <h3>Experience</h3>
+          <p>Security, software and operational work across organisations, education and practical business systems.</p>
+          <details class="experience-disclosure">
+            <summary>
+              <span>Work experience</span>
+              <span class="experience-disclosure-meta">
+                <span class="experience-disclosure-count">5 roles · 2022–Present</span>
+                <span class="experience-disclosure-state">
+                  <span class="experience-state-closed">Expand</span>
+                  <span class="experience-state-open">Collapse</span>
+                </span>
+              </span>
+            </summary>
+            <div class="experience-list">
+              <article class="experience-item">
+                <div><time datetime="2025-07">Jul 2025–Present</time><span>Intermittent</span></div>
+                <div><h4>IT &amp; Administration Support</h4><p class="experience-company">GMT Electrical Services Ltd</p><p>Developed the company website and a working staff portal for timesheets, audit checks and job-card workflows, alongside email, invoicing, calls and operational coordination.</p></div>
+              </article>
+              <article class="experience-item">
+                <div><time datetime="2025-05">May–Jun 2025</time></div>
+                <div><h4>Project &amp; Creative Director, Trustee</h4><p class="experience-company">CERRF</p><p>Directed cybersecurity learning tools including Inspector and HackerGo, with responsibility across workshops, product storytelling, interface design and cross-platform delivery.</p></div>
+              </article>
+              <article class="experience-item">
+                <div><time datetime="2025-01">Jan–Mar 2025</time></div>
+                <div><h4>Student Mentor &amp; Teaching Assistant</h4><p class="experience-company">Kingston University London</p><p>Supported undergraduate labs in Splunk, Datadog, AI automation, cloud data systems and Linux-based technical work.</p></div>
+              </article>
+              <article class="experience-item">
+                <div><time>2023–2025</time></div>
+                <div><h4>Systems Engineer &amp; Data Analyst</h4><p class="experience-company">Lunarversal</p><p>Worked across monitoring, Salesforce automation, GitHub access and testing, API configuration, OAuth and token-based integrations.</p></div>
+              </article>
+              <article class="experience-item">
+                <div><time>2022–2023</time></div>
+                <div><h4>Security Engineer</h4><p class="experience-company">Xeyus Ltd</p><p>Delivered penetration-testing support, security consultancy and GDPR-focused technical work.</p></div>
+              </article>
+            </div>
+          </details>
+        </div>
+        <a class="btn btn-primary" href="professional-work.html">View experience</a>
       </div>
     </div>
 

--- a/styles.css
+++ b/styles.css
@@ -688,6 +688,9 @@ body > .back-to-top {
 .about-overlay-card h2 { max-width:15ch; margin:.5rem 0 1rem; color:var(--white); font-family:'Playfair Display',Georgia,serif; font-size:clamp(1.8rem,4vw,3rem); line-height:1.05; }
 .about-overlay-card p:not(.projects-eyebrow) { max-width:58ch; color:var(--text-muted); line-height:1.7; }
 .about-overlay-card .btn { margin-top:1.2rem; }
+.about-overlay-experience { margin-top:1.5rem; }
+.about-overlay-experience > h3 { color:var(--white); font-size:1.35rem; margin:0 0 .45rem; }
+.about-overlay-experience > p { color:var(--text-muted); font-size:.9rem; line-height:1.65; margin:0 0 1rem; }
 .about-overlay-close { position:absolute; top:.8rem; right:1rem; width:2.4rem; height:2.4rem; border:1px solid rgba(244,201,93,.45); border-radius:50%; background:transparent; color:var(--white); cursor:pointer; font-size:1.5rem; line-height:1; }
 
 .hero-text {


### PR DESCRIPTION
Adds the existing Experience panel and expandable five-role work history to the About Me portrait overlay, while keeping the professional-work link available.